### PR TITLE
DB/ Implement dance rune weapon

### DIFF
--- a/data/sql/updates/db_world/2021_08_19_03_world.sql
+++ b/data/sql/updates/db_world/2021_08_19_03_world.sql
@@ -1,0 +1,6 @@
+DELETE FROM `smart_scripts` WHERE `entryorguid`=27893 AND `source_type`=0;
+UPDATE `creature_template` SET `speed_walk`=2.5, `speed_run`=2.5, `unit_flags` = 33554432, `flags_extra`=0,`AIName`='', `ScriptName`='npc_pet_dk_rune_weapon' WHERE `entry`=27893;
+
+DELETE FROM `spell_script_names` where `spell_id` IN (49028);
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(49028, 'spell_dk_dancing_rune_weapon');


### PR DESCRIPTION
damage is now halved, years ago it wasn't, so we got that going at least
stat scaling missing - the low damage might even come from this instead of the aura
periodic auras still unknown

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
