### PR TITLE
 DB/Spells: Blade's Edge Ogre Force Reaction (After completion of Int…

### DIFF
--- a/data/sql/updates/db_world/2021_04_28_07_world.sql
+++ b/data/sql/updates/db_world/2021_04_28_07_world.sql
@@ -1,0 +1,6 @@
+--
+UPDATE `spell_dbc` SET `AttributesEx`=`AttributesEx`|32, `AttributesEx2`=1, `AttributesEx3`=1048576, `RangeIndex`=13, `Effect1`=6, `Effect2`=6, `EffectDieSides1`=1, `EffectDieSides2`=1, `EffectBasePoints1`=2, `EffectBasePoints2`=2, `EffectImplicitTargetA1`=1, `EffectImplicitTargetA2`=1, `EffectApplyAuraName1`=139, `EffectApplyAuraName2`=139, `EffectMiscValue1`=929, `EffectMiscValue2`=1001, `DmgMultiplier1`=1, `DmgMultiplier2`=1, `SchoolMask`=0 WHERE  `Id`=39960;
+
+DELETE FROM `spell_area` WHERE `spell`=39960;
+INSERT INTO `spell_area` (`spell`, `area`, `quest_start`, `quest_end`, `aura_spell`, `racemask`, `gender`, `autocast`, `quest_start_status`, `quest_end_status`) VALUES 
+(39960, 3522, 11000, 0, 0, 0, 2, 1, 64, 11);


### PR DESCRIPTION
…o The Soulgrinder

 DB/Spells: Blade's Edge Ogre Force Reaction (After completion of Into The Soulgrinder

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
